### PR TITLE
Add LDOG token (Liquidog)

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -532,6 +532,17 @@
       "logoURI": "https://hyperpixies.art/logo_125x.png",
       "tags": [
         "tokenv1"
+        ]
+    },
+    {
+      "name": "Liquidog",
+      "decimals": 18,
+      "symbol": "LDOG",
+      "address": "0x5f2c04148D4a03A12fD97793189a5899acb06B6d",
+      "chainId": 999,
+      "logoURI": "https://raw.githubusercontent.com/Crypthaut/hyperswap-token-list/main/assets/ldog.png",
+      "tags": [
+        "tokenv1"
       ]
     }
   ],


### PR DESCRIPTION
Adds LDOG token to token list (chainId 999).
Includes logo (125x125 PNG) and full token metadata.
CA: 0x5f2c04148D4a03A12fD97793189a5899acb06B6d